### PR TITLE
Override default.can_interact_with_node

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -24,3 +24,16 @@ read_globals = {
 	"basic_materials",
 	"factions",
 }
+
+files["override_default_can_interact_with_node.lua"] = {
+	read_globals = {
+		default = {
+			fields = {
+				can_interact_with_node = {
+					read_only = false,
+					other_fields = false,
+				}
+			}
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Notes:
 ## Settings
 - Setting `keyring.personal_keyring` is available to disable/enable personal keyring (enabled by default).
 - Setting `keyring.playerfactions` is available to disable/enable the possiblity to share personal keyrings with factions (enabled by default).
+- Setting `keyring.override_default_can_interact_with_node` allow to automatically select key in the keyring when the interaction check is done with `default.can_interact_with_node`. This allow better integration with mods like `technic_chests`, where chests interaction is not checked on openning but when moving items.
 
 ## Privileges
 You can grant the privilege `keyring_inspect` to allow a player to list keys of personal keyrings owned by other players.

--- a/init.lua
+++ b/init.lua
@@ -3,13 +3,15 @@ local MP = minetest.get_modpath("keyring")
 keyring = {}
 
 -- mod information
-keyring.mod = {version = "1.2.4", author = "Louis Royer"}
+keyring.mod = {version = "1.2.5", author = "Louis Royer"}
 
 -- keyring settings
 keyring.settings =
 	{
 		personal_keyring = minetest.settings:get_bool("keyring.personal_keyring", true),
 		playerfactions = minetest.settings:get_bool("keyring.playerfactions", true),
+		override_default_can_interact_with_node = minetest.settings:get_bool(
+			"keyring.override_default_can_interact_with_node", true),
 	}
 
 -- disable playerfactions if not loaded
@@ -37,6 +39,9 @@ if not basic_materials.mod then
 	.."/-/archive/master/basic_materials-master.zip")
 end
 
+if keyring.settings.override_default_can_interact_with_node then
+	dofile(MP.."/override_default_can_interact_with_node.lua")
+end
 dofile(MP.."/privileges.lua")
 dofile(MP.."/meta_fields.lua")
 dofile(MP.."/formspec.lua")

--- a/override_default_can_interact_with_node.lua
+++ b/override_default_can_interact_with_node.lua
@@ -1,0 +1,25 @@
+if default.can_interact_with_node then
+	local original = default.can_interact_with_node
+	default.can_interact_with_node = function(player, pos, ...)
+		local result = original(player, pos, ...)
+		if not result then
+			local meta = minetest.get_meta(pos)
+			local item = player:get_wielded_item()
+
+			-- checking container is in hands
+			if minetest.get_item_group(item:get_name(), "key_container") ~= 1 then
+				return false
+			end
+
+			-- selecting key
+			local new_keyring = keyring.craft_common.select_key(item, player, meta)
+			if new_keyring ~= nil then
+				player:set_wielded_item(new_keyring)
+			end
+
+			-- re-run the test
+			return original(player, pos, ...)
+		end
+		return result
+	end
+end

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,2 +1,3 @@
 keyring.personal_keyring (Enable personal keyrings) bool true
 keyring.playerfactions (Enable the possiblity to share personal keyrings with factions) bool true
+keyring.override_default_can_interact_with_node (Override the default.can_interact_with_node method bool true

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,3 +1,3 @@
 keyring.personal_keyring (Enable personal keyrings) bool true
 keyring.playerfactions (Enable the possiblity to share personal keyrings with factions) bool true
-keyring.override_default_can_interact_with_node (Override the default.can_interact_with_node method bool true
+keyring.override_default_can_interact_with_node (Override the default.can_interact_with_node method) bool true


### PR DESCRIPTION
Setting `keyring.override_default_can_interact_with_node` allow to automatically select key in the keyring when the interaction check is done with `default.can_interact_with_node`. This allow better integration with mods like `technic_chests`, where chests interaction is not checked on opening but when moving items.